### PR TITLE
fix: prevent sparse action normalization spikes in pi0.5/pi0-fast

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ build/
 runs/
 adapter-tmp/
 .venv/
+.worktrees/
 __pycache__/
 assets/
 checkpoints

--- a/vla_arena/models/openpi/src/openpi/shared/normalize.py
+++ b/vla_arena/models/openpi/src/openpi/shared/normalize.py
@@ -26,6 +26,8 @@ class NormStats:
     std: numpydantic.NDArray
     q01: numpydantic.NDArray | None = None  # 1st quantile
     q99: numpydantic.NDArray | None = None  # 99th quantile
+    min: numpydantic.NDArray | None = None
+    max: numpydantic.NDArray | None = None
 
 
 class RunningStats:
@@ -109,7 +111,14 @@ class RunningStats:
         variance = self._mean_of_squares - self._mean**2
         stddev = np.sqrt(np.maximum(0, variance))
         q01, q99 = self._compute_quantiles([0.01, 0.99])
-        return NormStats(mean=self._mean, std=stddev, q01=q01, q99=q99)
+        return NormStats(
+            mean=self._mean,
+            std=stddev,
+            q01=q01,
+            q99=q99,
+            min=self._min,
+            max=self._max,
+        )
 
     def _adjust_histograms(self):
         """Adjust histograms when min or max changes."""

--- a/vla_arena/models/openpi/src/openpi/shared/normalize_test.py
+++ b/vla_arena/models/openpi/src/openpi/shared/normalize_test.py
@@ -38,6 +38,28 @@ def test_serialize_deserialize():
     )
     assert np.allclose(norm_stats['test'].mean, norm_stats2['test'].mean)
     assert np.allclose(norm_stats['test'].std, norm_stats2['test'].std)
+    assert np.allclose(norm_stats['test'].min, norm_stats2['test'].min)
+    assert np.allclose(norm_stats['test'].max, norm_stats2['test'].max)
+
+
+def test_deserialize_legacy_stats_without_min_max():
+    serialized = '''
+    {
+      "norm_stats": {
+        "test": {
+          "mean": [0.0, 1.0],
+          "std": [1.0, 2.0],
+          "q01": [-1.0, 0.0],
+          "q99": [1.0, 2.0]
+        }
+      }
+    }
+    '''
+
+    norm_stats = normalize.deserialize_json(serialized)
+
+    assert norm_stats['test'].min is None
+    assert norm_stats['test'].max is None
 
 
 def test_multiple_batch_dimensions():

--- a/vla_arena/models/openpi/src/openpi/transforms.py
+++ b/vla_arena/models/openpi/src/openpi/transforms.py
@@ -30,6 +30,55 @@ DataDict: TypeAlias = at.PyTree
 NormStats: TypeAlias = _normalize.NormStats
 
 
+_NORM_EPS = 1e-6
+
+
+@dataclasses.dataclass(frozen=True)
+class _QuantileStats:
+    q01: np.ndarray
+    q99: np.ndarray
+    quantile_range: np.ndarray
+    min_value: np.ndarray | None
+    max_value: np.ndarray | None
+    full_range: np.ndarray | None
+    degenerate_mask: np.ndarray
+    minmax_fallback_mask: np.ndarray | None
+
+
+def _get_quantile_stats(stats: NormStats, dim: int) -> _QuantileStats:
+    assert stats.q01 is not None
+    assert stats.q99 is not None
+    q01 = stats.q01[..., :dim]
+    q99 = stats.q99[..., :dim]
+    quantile_range = q99 - q01
+    degenerate_mask = quantile_range < _NORM_EPS
+    if stats.min is None or stats.max is None:
+        return _QuantileStats(
+            q01=q01,
+            q99=q99,
+            quantile_range=quantile_range,
+            min_value=None,
+            max_value=None,
+            full_range=None,
+            degenerate_mask=degenerate_mask,
+            minmax_fallback_mask=None,
+        )
+
+    min_value = stats.min[..., :dim]
+    max_value = stats.max[..., :dim]
+    full_range = max_value - min_value
+    return _QuantileStats(
+        q01=q01,
+        q99=q99,
+        quantile_range=quantile_range,
+        min_value=min_value,
+        max_value=max_value,
+        full_range=full_range,
+        degenerate_mask=degenerate_mask,
+        minmax_fallback_mask=degenerate_mask & (full_range > _NORM_EPS),
+    )
+
+
 T = TypeVar('T')
 S = TypeVar('S')
 
@@ -167,10 +216,20 @@ class Normalize(DataTransformFn):
         return (x - mean) / (std + 1e-6)
 
     def _normalize_quantile(self, x, stats: NormStats):
-        assert stats.q01 is not None
-        assert stats.q99 is not None
-        q01, q99 = stats.q01[..., : x.shape[-1]], stats.q99[..., : x.shape[-1]]
-        return (x - q01) / (q99 - q01 + 1e-6) * 2.0 - 1.0
+        quantile_stats = _get_quantile_stats(stats, x.shape[-1])
+        normalized = (x - quantile_stats.q01) / (quantile_stats.quantile_range + _NORM_EPS) * 2.0 - 1.0
+        if quantile_stats.minmax_fallback_mask is None:
+            return normalized
+
+        assert quantile_stats.min_value is not None
+        assert quantile_stats.max_value is not None
+        assert quantile_stats.full_range is not None
+        minmax_normalized = (x - quantile_stats.min_value) / (quantile_stats.full_range + _NORM_EPS) * 2.0 - 1.0
+        return np.where(
+            quantile_stats.degenerate_mask,
+            np.where(quantile_stats.minmax_fallback_mask, minmax_normalized, 0.0),
+            normalized,
+        )
 
 
 @dataclasses.dataclass(frozen=True)
@@ -206,17 +265,24 @@ class Unnormalize(DataTransformFn):
 
     def _unnormalize_quantile(self, x, stats: NormStats):
         assert stats.q01 is not None
-        assert stats.q99 is not None
-        q01, q99 = stats.q01, stats.q99
-        if (dim := q01.shape[-1]) < x.shape[-1]:
-            return np.concatenate(
-                [
-                    (x[..., :dim] + 1.0) / 2.0 * (q99 - q01 + 1e-6) + q01,
-                    x[..., dim:],
-                ],
-                axis=-1,
+        dim = min(stats.q01.shape[-1], x.shape[-1])
+        x_normalized = x[..., :dim]
+        quantile_stats = _get_quantile_stats(stats, dim)
+
+        unnormalized = (x_normalized + 1.0) / 2.0 * (quantile_stats.quantile_range + _NORM_EPS) + quantile_stats.q01
+        if quantile_stats.minmax_fallback_mask is not None:
+            assert quantile_stats.min_value is not None
+            assert quantile_stats.full_range is not None
+            minmax_unnormalized = (x_normalized + 1.0) / 2.0 * (quantile_stats.full_range + _NORM_EPS) + quantile_stats.min_value
+            unnormalized = np.where(
+                quantile_stats.degenerate_mask,
+                np.where(quantile_stats.minmax_fallback_mask, minmax_unnormalized, quantile_stats.q01),
+                unnormalized,
             )
-        return (x + 1.0) / 2.0 * (q99 - q01 + 1e-6) + q01
+
+        if dim < x.shape[-1]:
+            return np.concatenate([unnormalized, x[..., dim:]], axis=-1)
+        return unnormalized
 
 
 @dataclasses.dataclass(frozen=True)

--- a/vla_arena/models/openpi/src/openpi/transforms_test.py
+++ b/vla_arena/models/openpi/src/openpi/transforms_test.py
@@ -14,6 +14,7 @@
 
 import numpy as np
 import vla_arena.models.openpi.src.openpi.models.tokenizer as _tokenizer
+import vla_arena.models.openpi.src.openpi.shared.normalize as _normalize
 import vla_arena.models.openpi.src.openpi.transforms as _transforms
 import pytest
 
@@ -153,3 +154,71 @@ def test_extract_prompt_from_task():
         ValueError, match='task_index=2 not found in task mapping'
     ):
         transform({'task_index': 2})
+
+
+def test_quantile_normalize_falls_back_to_minmax_for_sparse_nonzero_dim():
+    stats = _normalize.NormStats(
+        mean=np.array([0.0, 0.0]),
+        std=np.array([1.0, 0.03]),
+        q01=np.array([-1.0, 0.0]),
+        q99=np.array([1.0, 0.0]),
+        min=np.array([-1.0, -0.675]),
+        max=np.array([1.0, 0.45]),
+    )
+    transform = _transforms.Normalize({'actions': stats}, use_quantiles=True)
+
+    data = transform({'actions': np.array([[0.0, 0.45]])})
+
+    assert np.allclose(data['actions'], np.array([[0.0, 1.0]]), atol=1e-5)
+
+
+def test_quantile_unnormalize_matches_minmax_fallback():
+    stats = _normalize.NormStats(
+        mean=np.array([0.0, 0.0]),
+        std=np.array([1.0, 0.03]),
+        q01=np.array([-1.0, 0.0]),
+        q99=np.array([1.0, 0.0]),
+        min=np.array([-1.0, -0.675]),
+        max=np.array([1.0, 0.45]),
+    )
+    normalize = _transforms.Normalize({'actions': stats}, use_quantiles=True)
+    unnormalize = _transforms.Unnormalize({'actions': stats}, use_quantiles=True)
+    actions = np.array([[0.0, 0.45], [0.5, -0.675]])
+
+    normalized = normalize({'actions': actions})['actions']
+    recovered = unnormalize({'actions': normalized})['actions']
+
+    assert np.allclose(recovered, actions, atol=1e-5)
+
+
+def test_quantile_normalize_keeps_legacy_behavior_without_minmax_stats():
+    stats = _normalize.NormStats(
+        mean=np.array([0.0]),
+        std=np.array([1.0]),
+        q01=np.array([0.0]),
+        q99=np.array([0.0]),
+    )
+    transform = _transforms.Normalize({'actions': stats}, use_quantiles=True)
+
+    data = transform({'actions': np.array([[0.45]])})
+
+    assert data['actions'][0, 0] > 100000
+
+
+def test_quantile_normalize_constant_dim_with_minmax_stats_outputs_zero():
+    stats = _normalize.NormStats(
+        mean=np.array([0.0]),
+        std=np.array([0.0]),
+        q01=np.array([0.0]),
+        q99=np.array([0.0]),
+        min=np.array([0.0]),
+        max=np.array([0.0]),
+    )
+    normalize = _transforms.Normalize({'actions': stats}, use_quantiles=True)
+    unnormalize = _transforms.Unnormalize({'actions': stats}, use_quantiles=True)
+
+    normalized = normalize({'actions': np.array([[0.0]])})['actions']
+    recovered = unnormalize({'actions': normalized})['actions']
+
+    assert np.allclose(normalized, np.array([[0.0]]))
+    assert np.allclose(recovered, np.array([[0.0]]))


### PR DESCRIPTION
# Description

This PR fixes unstable action normalization for PI0.5 and PI0-FAST on VLA-Arena datasets.                                         
                                                                                                                                    
  VLA-Arena actions use 7D end-effector delta controls:                                                                             
  `[x, y, z, roll, pitch, yaw, gripper]`.                  
                                                                                                                                    
  For some VLA-Arena datasets, rotation dimensions are extremely sparse. In a sampled subset of `VLA_Arena_L1_L_lerobot_openpi`,    
  `pitch` and `yaw` contain rare non-zero values, while their 1st and 99th percentiles are both zero.                               
                                                                                                                                    
  PI0.5 and PI0-FAST use quantile normalization:                                                                                    
  
  ```python                                                                                                                         
  (x - q01) / (q99 - q01 + eps) * 2 - 1              
```      
                                                                                                                                    
  When q01 == q99 == 0, rare non-zero rotation actions can be scaled by 1 / eps, producing very large normalized action targets.    
  This can cause unstable training or exploding gradients.  

Fixes # (issue)

This PR keeps the default quantile normalization for normal dimensions, but falls back to min/max normalization when:             
  
  - the quantile range is degenerate, and                                                                                           
  - the full min/max range is non-zero.                    
                                                                                                                                    
  Constant dimensions are normalized to zero. Legacy checkpoints without min/max stats keep the previous behavior. 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test coverage improvement

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, don't hesitate to ask. We are here to help!

- [x] I have read the [CONTRIBUTION](https://github.com/PKU-Alignment/VLA-Arena/blob/main/CONTRIBUTING.md) guide. (**required**)
- [x] My change requires a change to the documentation.
- [x] I have updated the tests accordingly. (*required for a bug fix or a new feature*)
- [x] I have updated the documentation accordingly.
- [x] I have reformatted the code using `make format`. (**required**)
- [x] I have checked the code using `make lint`. (**required**)
- [x] I have ensured `make test` pass. (**required**)

## Testing

Please describe the tests that you ran to verify your changes:

- [ ] Test A
- [ ] Test B
