### PR TITLE
Fix degenerate quantile normalization

### DIFF
--- a/vla_arena/models/openpi/src/openpi/transforms.py
+++ b/vla_arena/models/openpi/src/openpi/transforms.py
@@ -170,7 +170,13 @@ class Normalize(DataTransformFn):
         assert stats.q01 is not None
         assert stats.q99 is not None
         q01, q99 = stats.q01[..., : x.shape[-1]], stats.q99[..., : x.shape[-1]]
-        return (x - q01) / (q99 - q01 + 1e-6) * 2.0 - 1.0
+        quantile_span = q99 - q01
+        quantile = (x - q01) / (quantile_span + 1e-6) * 2.0 - 1.0
+        return np.where(
+            quantile_span > 1e-6,
+            quantile,
+            self._normalize(x, stats),
+        )
 
 
 @dataclasses.dataclass(frozen=True)
@@ -211,12 +217,18 @@ class Unnormalize(DataTransformFn):
         if (dim := q01.shape[-1]) < x.shape[-1]:
             return np.concatenate(
                 [
-                    (x[..., :dim] + 1.0) / 2.0 * (q99 - q01 + 1e-6) + q01,
+                    self._unnormalize_quantile(x[..., :dim], stats),
                     x[..., dim:],
                 ],
                 axis=-1,
             )
-        return (x + 1.0) / 2.0 * (q99 - q01 + 1e-6) + q01
+        quantile_span = q99 - q01
+        quantile = (x + 1.0) / 2.0 * (quantile_span + 1e-6) + q01
+        return np.where(
+            quantile_span > 1e-6,
+            quantile,
+            self._unnormalize(x, stats),
+        )
 
 
 @dataclasses.dataclass(frozen=True)


### PR DESCRIPTION
## Summary

- Fall back to z-score normalization per dimension when `q99 - q01 <= 1e-6`.
- Apply the same fallback during unnormalization so the transform remains symmetric.
- Preserve action dimensions that do not have normalization statistics.

## Motivation

Constant or nearly constant dimensions can have a degenerate quantile range. Applying quantile scaling to those dimensions amplifies tiny numerical differences into very large normalized values. The existing mean and standard deviation statistics already provide a stable fallback for those dimensions.

## Compatibility

The change is limited to degenerate dimensions when quantile normalization is enabled. Valid quantile ranges continue to use the existing formula, and the default z-score path (`use_quantiles=False`) is unchanged. No model, data loader, or policy configuration is modified.

## Validation

- Targeted local regression tests: 5 passed.
- Red/green check: the original implementation failed the two fallback-specific cases; the patched implementation passes all five cases.
- Python compilation check passed for the modified module.
- `git diff --check` passed.
